### PR TITLE
Adding HDMI parameter for xrandr command

### DIFF
--- a/MMM-PIR-Sensor-Lite.js
+++ b/MMM-PIR-Sensor-Lite.js
@@ -19,6 +19,7 @@ Module.register("MMM-PIR-Sensor-Lite", {
 		deactivateDelay: 15 * 60 * 1000, // 15 minutes
 		updateInterval: 1000, // 1 second
 		animationSpeed: 1000, // 1 second
+		hdmiPort: 1, // 1 or 2
 		showCountDown: true,
 		showDetection: true,
 		hoursLabel: 'h',

--- a/MMM-PIR-Sensor-Lite.js
+++ b/MMM-PIR-Sensor-Lite.js
@@ -16,10 +16,10 @@ Module.register("MMM-PIR-Sensor-Lite", {
 		commandType: 'xrandr', // Type of command used
 		title: "Automatic Standby",
 		rotation: 'normal',
+		hdmiPort: 'HDMI-1', 
 		deactivateDelay: 15 * 60 * 1000, // 15 minutes
 		updateInterval: 1000, // 1 second
 		animationSpeed: 1000, // 1 second
-		hdmiPort: 1, // 1 or 2
 		showCountDown: true,
 		showDetection: true,
 		hoursLabel: 'h',

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The following properties can be configured:
 | `commandType`                | The command used to manage monitor. <br><br> **Possible values:** `'vcgencmd'`, `'xrandr'` or `'xset'` <br> **Default value:** `'xrandr'`
 | `title`                      | The title. It's hidden if `title: ""` <br><br> **Default value:** `"Automatic Standby"`
 | `rotation`                   | Direction of content rotation. <br><br> **Possible values:** `'normal'`, `'left'`, `'right'` or `'inverted'` <br> **Default value:** `'normal'`
+| `hdmiPort`                   | Select the HDMI-Port (requried for commandType `'xrandr'`) <br><br> **Possible values:** `1` or `2` <br> **Default value:** `1`
 | `deactivateDelay`            | How often does the content needs to be fetched? (Milliseconds) <br><br> **Possible values:** `1000` - `86400000` <br> **Default value:** `15 * 60 * 1000` (15 minutes)
 | `updateInterval`             | How often does the countdown needs to be updated? (Milliseconds) <br><br> **Possible values:**`0` - `5000` <br> **Default value:** `1000` (1 second)
 | `animationSpeed`             | Speed of the update animation. (Milliseconds) <br><br> **Possible values:**`0` - `5000` <br> **Default value:** `1000` (1 second)

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The following properties can be configured:
 | `commandType`                | The command used to manage monitor. <br><br> **Possible values:** `'vcgencmd'`, `'xrandr'` or `'xset'` <br> **Default value:** `'xrandr'`
 | `title`                      | The title. It's hidden if `title: ""` <br><br> **Default value:** `"Automatic Standby"`
 | `rotation`                   | Direction of content rotation. <br><br> **Possible values:** `'normal'`, `'left'`, `'right'` or `'inverted'` <br> **Default value:** `'normal'`
-| `hdmiPort`                   | Select the HDMI-Port (requried for commandType `'xrandr'`) <br><br> **Possible values:** `1` or `2` <br> **Default value:** `1`
+| `hdmiPort`                   | Select the HDMI-Port (requried for commandType `'xrandr'`) <br><br> **Possible values:** `HDMI-1` or `HDMI-2` <br> **Default value:** `HDMI-1`
 | `deactivateDelay`            | How often does the content needs to be fetched? (Milliseconds) <br><br> **Possible values:** `1000` - `86400000` <br> **Default value:** `15 * 60 * 1000` (15 minutes)
 | `updateInterval`             | How often does the countdown needs to be updated? (Milliseconds) <br><br> **Possible values:**`0` - `5000` <br> **Default value:** `1000` (1 second)
 | `animationSpeed`             | Speed of the update animation. (Milliseconds) <br><br> **Possible values:**`0` - `5000` <br> **Default value:** `1000` (1 second)

--- a/node_helper.js
+++ b/node_helper.js
@@ -46,7 +46,7 @@ module.exports = NodeHelper.create({
 				break;
 
 			case 'xrandr':
-				exec("xrandr --output HDMI-1 --rotate " + this.config.rotation + " --auto", null);
+				exec("xrandr --output HDMI-" + this.config.hdmiPort + " --rotate " + this.config.rotation + " --auto", null);
 				break;
 
 			case 'xset':

--- a/node_helper.js
+++ b/node_helper.js
@@ -64,7 +64,7 @@ module.exports = NodeHelper.create({
 				break;
 
 			case 'xrandr':
-				exec("xrandr --output HDMI-1 --off", null);
+				exec("xrandr --output " + this.config.hdmiPort + " --off", null);
 				break;
 
 			case 'xset':

--- a/node_helper.js
+++ b/node_helper.js
@@ -46,7 +46,7 @@ module.exports = NodeHelper.create({
 				break;
 
 			case 'xrandr':
-				exec("xrandr --output HDMI-" + this.config.hdmiPort + " --rotate " + this.config.rotation + " --auto", null);
+				exec("xrandr --output " + this.config.hdmiPort + " --rotate " + this.config.rotation + " --auto", null);
 				break;
 
 			case 'xset':


### PR DESCRIPTION
Allowing user to choose between HDMI-1 or HDMI-2 output port for xrandr command.