### PR TITLE
Fixed issue w/ xrandr not working on RPi4 Bullseye

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -53,7 +53,7 @@ module.exports = NodeHelper.create({
 					break;
 
 				case 'xrandr':
-					exec("xrandr --output " + this.config.hdmiPort + " --rotate " + this.config.rotation + " --auto", null);
+					exec("DISPLAY=:0 xrandr --output " + this.config.hdmiPort + " --rotate " + this.config.rotation + " --auto", null);
 					break;
 
 				case 'xset':
@@ -74,7 +74,7 @@ module.exports = NodeHelper.create({
 					break;
 
 				case 'xrandr':
-					exec("xrandr --output " + this.config.hdmiPort + " --off", null);
+					exec("DISPLAY=:0 xrandr --output " + this.config.hdmiPort + " --off", null);
 					break;
 
 				case 'xset':


### PR DESCRIPTION
Added `DISPLAY=:0` variable to xrandr commands (both activate and deactivate). Tested on Raspberry Pi 4 running Bullseye.

Seems to fix the issue where the command to turn the screen on/off executes but doesn't affect the monitor.